### PR TITLE
fix check_cli_version failure when installed aws-cli is a higher major version

### DIFF
--- a/load-balancing/elb-v2/common_functions.sh
+++ b/load-balancing/elb-v2/common_functions.sh
@@ -685,14 +685,22 @@ check_cli_version() {
     msg "Checking minimum required CLI version (${min_version}) against installed version ($version)"
 
     if [ $x -lt $min_x ]; then
+        # major version is less than required. fail.
         return 1
+    elif [ $x -gt $min_x ]; then
+        # major version is greater than required. succeed.
+        return 0
     elif [ $y -lt $min_y ]; then
+        # minor version is less than required. fail.
         return 1
     elif [ $y -gt $min_y ]; then
+        # minor version is greater than required. succeed.
         return 0
     elif [ $z -ge $min_z ]; then
+        # patch version is at least the required version. succeed.
         return 0
     else
+        # patch version is insufficient. fail.
         return 1
     fi
 }


### PR DESCRIPTION
*Issue #, if available:*
AFAIK there is not an open issue about this.

*Description of changes:*
This fixes an error we were seeing when the installed CLI was version 2.x.x (e.g. 2.0.20) and the minimum version was 1.x.x (e.g. 1.10.55). Also adds comments to improve code readability.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
